### PR TITLE
Fix ShareTo constructor to be compatible with AbstractShare

### DIFF
--- a/Block/AbstractShare.php
+++ b/Block/AbstractShare.php
@@ -1,16 +1,19 @@
 <?php
-/**
- * AbstractShare
- */
 
 namespace Unet\SocialShare\Block;
 
-/**
- * Class AbstractShare
- * @package Unet\SocialShare\Block
- */
-abstract class AbstractShare extends \Magento\Framework\View\Element\Template implements \Unet\SocialShare\Adapter\SocialAdapter
+use Magento\Framework\View\Element\Template;
+use Unet\SocialShare\Adapter\SocialAdapter;
+
+abstract class AbstractShare extends Template implements SocialAdapter
 {
+    const FACEBOOK_ENABLE_PATH = 'social_share/facebook/facebook_enable';
+    const TWITTER_ENABLE_PATH = 'social_share/twitter/twitter_enable';
+    const GOOGLE_PLUS_ENABLE_PATH = 'social_share/network/google_plus_enable';
+    const PINTEREST_ENABLE_PATH = 'social_share/network/pinterest_enable';
+    const FACEBOOK_APP_ID = 'social_share/facebook/facebook_app_id';
+    const TWITTER_NAME = 'social_share/twitter/twitter_site_name';
+
     /**
      * @var \Unet\SocialShare\Helper\Data
      */
@@ -21,24 +24,6 @@ abstract class AbstractShare extends \Magento\Framework\View\Element\Template im
      */
     protected $openGraph;
 
-    const FACEBOOK_ENABLE_PATH = 'social_share/facebook/facebook_enable';
-
-    const TWITTER_ENABLE_PATH = 'social_share/twitter/twitter_enable';
-
-    const GOOGLE_PLUS_ENABLE_PATH = 'social_share/network/google_plus_enable';
-
-    const PINTEREST_ENABLE_PATH = 'social_share/network/pinterest_enable';
-
-    const FACEBOOK_APP_ID = 'social_share/facebook/facebook_app_id';
-
-    const TWITTER_NAME = 'social_share/twitter/twitter_site_name';
-
-    /**
-     * AbstractShare constructor.
-     * @param \Magento\Framework\View\Element\Template\Context $context
-     * @param \Unet\SocialShare\Helper\Data $helper
-     * @param array $data
-     */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
         \Unet\SocialShare\Helper\Data $helper,
@@ -51,28 +36,27 @@ abstract class AbstractShare extends \Magento\Framework\View\Element\Template im
     }
 
     /**
-     * getShareConfig
      * @return array
      */
     public function getShareConfig()
     {
         $config = [
-            'facebook' => [
+            'facebook'  => [
                 'enable' => $this->helper->getStoreConfig(self::FACEBOOK_ENABLE_PATH),
-                'link' => \Unet\SocialShare\Adapter\SocialAdapter::FACEBOOK_SHARE_LINK
+                'link'   => SocialAdapter::FACEBOOK_SHARE_LINK,
             ],
-            'twitter' => [
+            'twitter'   => [
                 'enable' => $this->helper->getStoreConfig(self::TWITTER_ENABLE_PATH),
-                'link' => \Unet\SocialShare\Adapter\SocialAdapter::TWITTER_SHARE_LINK
+                'link'   => SocialAdapter::TWITTER_SHARE_LINK,
             ],
-            'gplus' => [
+            'gplus'     => [
                 'enable' => $this->helper->getStoreConfig(self::GOOGLE_PLUS_ENABLE_PATH),
-                'link' => \Unet\SocialShare\Adapter\SocialAdapter::GOOGLE_PLUS_SHARE_LINK
+                'link'   => SocialAdapter::GOOGLE_PLUS_SHARE_LINK,
             ],
             'pinterest' => [
                 'enable' => $this->helper->getStoreConfig(self::PINTEREST_ENABLE_PATH),
-                'link' => \Unet\SocialShare\Adapter\SocialAdapter::PINTEREST_SHARE_LINK
-            ]
+                'link'   => SocialAdapter::PINTEREST_SHARE_LINK,
+            ],
         ];
 
         return $config;

--- a/Block/Widget/ShareTo.php
+++ b/Block/Widget/ShareTo.php
@@ -1,34 +1,24 @@
 <?php
-/**
- * ShareTo
- */
 
 namespace Unet\SocialShare\Block\Widget;
 
-/**
- * Class Share
- * @package Unet\SocialShare\Block\Widget
- */
-class ShareTo extends \Unet\SocialShare\Block\AbstractShare implements \Magento\Widget\Block\BlockInterface
+use Magento\Widget\Block\BlockInterface;
+use Unet\SocialShare\Block\AbstractShare;
+
+class ShareTo extends AbstractShare implements BlockInterface
 {
     /**
-     * $template
      * @var string
      */
     protected $template = "Unet_SocialShare::shareto.phtml";
 
-    /**
-     * ShareTo constructor.
-     * @param \Magento\Framework\View\Element\Template\Context $context
-     * @param \Unet\SocialShare\Helper\Data $helper
-     * @param array $data
-     */
     public function __construct(
         \Magento\Framework\View\Element\Template\Context $context,
         \Unet\SocialShare\Helper\Data $helper,
-        array $data
+        \Unet\SocialShare\Block\OpenGraph $openGraph,
+        array $data = []
     ) {
-        parent::__construct($context, $helper, $data);
+        parent::__construct($context, $helper, $openGraph, $data);
         $this->setTemplate($this->template);
     }
 }


### PR DESCRIPTION
In ShareTo constructor, the call to parent::__construct was invoked with invalid parameters due to recent AbstractShare change. This PR fix that issue