### PR TITLE
removed default twitter site name from config.xml

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -16,7 +16,6 @@
             </facebook>
             <twitter>
                 <twitter_enable>1</twitter_enable>
-                <twitter_site_name>unetstudio</twitter_site_name>
             </twitter>
             <network>
                 <google_plus_enable>1</google_plus_enable>


### PR DESCRIPTION
This is for Issue #23 as part of Hacktoberfest. I removed the default value for the Twitter Site Name from config.xml, so the field will be null by default.